### PR TITLE
Fix de l'execution de mysql_upgrade

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,6 +15,16 @@
     force: "{{ overwrite_global_mycnf }}"
   notify: restart mysql
 
+- name: Copy debian.cnf global MySQL configuration.
+  template:
+    src: debian.cnf.j2
+    dest: "/etc/mysql/debian.cnf"
+    owner: root
+    group: root
+    mode: 0600
+    force: true
+  notify: restart mysql
+
 - name: Verify mysql include directory exists.
   file:
     path: "{{ mysql_config_include_dir }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,6 +15,15 @@
     force: "{{ overwrite_global_mycnf }}"
   notify: restart mysql
 
+- name: Copy logrotate configuration.
+  template:
+    src: logrotate.cnf.j2
+    dest: /etc/logrotate.d/mariadb
+    owner: root
+    group: root
+    mode: 0644
+    force: true
+
 - name: Copy debian.cnf global MySQL configuration.
   template:
     src: debian.cnf.j2

--- a/templates/debian.cnf.j2
+++ b/templates/debian.cnf.j2
@@ -1,0 +1,10 @@
+[client]
+host     =localhost
+user     ="{{ mysql_root_username }}"
+password ="{{ mysql_root_password }}"
+socket   ={{ mysql_socket }}
+[mysql_upgrade]
+host     =localhost
+user     ="{{ mysql_root_username }}"
+password ="{{ mysql_root_password }}"
+socket   ={{ mysql_socket }}

--- a/templates/logrotate.cnf.j2
+++ b/templates/logrotate.cnf.j2
@@ -1,0 +1,51 @@
+/var/lib/mysql/mysqld.log /var/lib/mysql/mariadb.log /var/log/mysql/*.log {
+
+  # Depends on a mysql@localhost unix_socket authenticated user with RELOAD privilege
+  su mysql {{ mysql_log_file_group }}
+
+  # If any of the files listed above is missing, skip them silently without
+  # emitting any errors
+  missingok
+
+  # If file exists but is empty, don't rotate it
+  notifempty
+
+  # Run monthly
+  monthly
+
+  # Keep 6 months of logs
+  rotate 6
+
+  # If file is growing too big, rotate immediately
+  maxsize 500M
+
+  # If file size is too small, don't rotate at all
+  minsize 50M
+
+  # Compress logs, as they are text and compression will save a lot of disk space
+  compress
+
+  # Don't compress the log immediately to avoid errors about "file size changed while zipping"
+  delaycompress
+
+  # Don't run the postrotate script for each file configured in this file, but
+  # run it only once if one or more files were rotated
+  sharedscripts
+
+  # After each rotation, run this custom script to flush the logs. Note that
+  # this assumes that the mariadb-admin command has database access, which it
+  # has thanks to the default use of Unix socket authentication for the 'mysql'
+  # (or root on Debian) account used everywhere since MariaDB 10.4.
+  postrotate
+    if test -r /etc/mysql/debian.cnf
+    then
+      EXTRAPARAM='--defaults-file=/etc/mysql/debian.cnf'
+    fi
+
+    if test -x /usr/bin/mariadb-admin
+    then
+      /usr/bin/mariadb-admin $EXTRAPARAM --local flush-error-log \
+        flush-engine-log flush-general-log flush-slow-log
+    fi
+  endscript
+}


### PR DESCRIPTION
## Problème 

Lors du démarrage de mariadb, il est prévu que le moteur vérifie s'il a besoin de mettre à jour des tables. C'est cette ligne : `MYUPGRADE="/usr/bin/mysql_upgrade --defaults-extra-file=/etc/mysql/debian.cnf --version-check --silent"` du fichier `/etc/mysql/debian-start` qui fait le job.

Or, le rôle Ansible ne passe pas par le chemin attendu spécifiquement par Debian pour modifier l'utilisateur `root` de la BDD. Par conséquent, le fichier `/etc/mysql/debian.cnf` ne contient pas la bonne configuration.

On peut d'ailleurs voir dans https://github.com/geerlingguy/ansible-role-mysql/issues/421 et https://github.com/geerlingguy/ansible-role-mysql/issues/431 que globalement, ces soucis là n'ont jamais été traités.

## Solution

En solution simple et pas prise de tête, je réécris le fichier de configuration avec les données du rôle.

## Remarque

Ajout de la configuration du "logrotate" de MySQL pour ajouter `su` à la commande de récupération des logs à rotater.
Ainsi les logs sont maintenant rotatés, ce qui n'était précédemment pas le cas.